### PR TITLE
Update 4-storageclass.yaml

### DIFF
--- a/3-NFS_Storage/4-storageclass.yaml
+++ b/3-NFS_Storage/4-storageclass.yaml
@@ -3,7 +3,7 @@ kind: StorageClass
 metadata:
   name: nfs-ssd1
   annotations:
-    storageclass.kubernetes.io/is-default-class: true
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: nfs-provisioner/nfs-ssd1
 parameters:
   archiveOnDelete: "true"


### PR DESCRIPTION
Fix error 
error: unable to decode "4-storageclass.yaml.1": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Annotations: ReadString: expects " or n, but found t, error found in #10 byte of ...|t-class":true},"name|..., bigger context ...|":{"storageclass.kubernetes.io/is-default-class":true},"name":"nfs-ssd1"},"parameters":{"archiveOnDe|...